### PR TITLE
Enhances `Makefile` to make build dependencies self documenting.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,23 +2,23 @@
 
 VERSION = $(shell cat VERSION)
 
-compile: node_modules clean
+compile: clean node_modules components
 	@node build/minify.js
 
 site: homepage downloadpage docs demos
 
-demos: node_modules
+demos: node_modules components
 	@node build/demos.js
 
 homepage: node_modules
 	@$(RM) -f index.html
 	@node build/homepage.js
 
-downloadpage: node_modules
+downloadpage: node_modules components
 	@$(RM) -f download.html
 	@node build/download.js
 
-docs: node_modules
+docs: node_modules components
 	@$(RM) -f docs.html
 	@node build/docs.js
 
@@ -28,9 +28,12 @@ cleandocs:
 clean:
 	@$(RM) -f dist/brick.js dist/brick.css
 
-node_modules: package.json component/**/component.json
+node_modules: package.json
 	@git submodule update --init --recursive
 	@npm install
+
+components: component/**/component.json
+	@git submodule update --init --recursive
 
 release: compile
 	@cp dist/brick.js brick-$(VERSION).js

--- a/Makefile
+++ b/Makefile
@@ -2,34 +2,38 @@
 
 VERSION = $(shell cat VERSION)
 
-compile: clean
+compile: node_modules clean
 	@node build/minify.js
 
 site: homepage downloadpage docs demos
 
-demos:
+demos: node_modules
 	@node build/demos.js
 
-homepage:
-	@rm -f index.html
+homepage: node_modules
+	@$(RM) -f index.html
 	@node build/homepage.js
 
-downloadpage:
-	@rm -f download.html
+downloadpage: node_modules
+	@$(RM) -f download.html
 	@node build/download.js
 
-docs:
-	@rm -f docs.html
+docs: node_modules
+	@$(RM) -f docs.html
 	@node build/docs.js
 
 cleandocs:
-	@rm -f docs.html
+	@$(RM) -f docs.html
 
 clean:
-	@rm -f dist/brick.js dist/brick.css
+	@$(RM) -f dist/brick.js dist/brick.css
+
+node_modules: package.json dist/*/*.min.js
+	@git submodule update --init --recursive
+	@npm install
 
 release: compile
 	@cp dist/brick.js brick-$(VERSION).js
 	@cp dist/brick.css brick-$(VERSION).css
 	@zip brick-$(VERSION).zip brick-$(VERSION).js brick-$(VERSION).css
-	@rm brick-$(VERSION).js brick-$(VERSION).css
+	@$(RM) brick-$(VERSION).js brick-$(VERSION).css

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ cleandocs:
 clean:
 	@$(RM) -f dist/brick.js dist/brick.css
 
-node_modules: package.json dist/*/*.min.js
+node_modules: package.json component/**/component.json
 	@git submodule update --init --recursive
 	@npm install
 


### PR DESCRIPTION
### Summary
- All build tasks requiring `npm` dependencies depend on `node_modules`
  target.
- `node_modules` file/directory target depends on `package.json` and
  `dist/*/*.min.js` files. Person building can never forget a step.
- Use the variable `$(RM)`.
### Benefit

No need to remember to run `npm install` or `git submodule ...` when a new component submodule is added or `package.json` is updated. `make` file dependency tracking takes care of this.
### Acceptance Criteria

```
% cd /tmp
% rm -rf brick ; git clone https://github.com/mozilla/brick.git ; cd brick
% make demos # notice the error
% curl -s https://raw.github.com/wilmoore/brick/quick-contributor-start/Makefile > Makefile
% make demos # this time all the dependencies will be worked out and the demos will be created
% make demos # all up-to-date tasks won't run again this time...the demos will be made either way since it sits in a `.PHONE` target
```

The above steps should result in updated submodules, npm install, and demos being created without errors.
