### PR TITLE
Fixed bug in build system

### DIFF
--- a/build/statictools.js
+++ b/build/statictools.js
@@ -103,19 +103,29 @@ var getComponents = avow(function(fulfill, reject, componentsJson){
 });
 
 var flattenBowerDep = function(bower_data){
-  var result = {};
-  var flatten = function(data){
+  var result = {}, oresult = [];
+  var flatten = function(item, data){
     Object.keys(data||{}).forEach(function(key){
-      if(!result[key]){
+      if (!result[key]){
+        if (item){
+          var parentIdx = oresult.indexOf(item);
+          oresult.splice(parentIdx,0, key);
+        } else{
+          oresult.push(key);
+        }
         result[key] = data[key];
-        if(data[key].dependencies){
-          flatten(data[key].dependencies);
+        if (data[key].dependencies){
+          flatten(key, data[key].dependencies);
         }
       }
     });
   };
-  flatten(bower_data.dependencies);
-  return result;
+  flatten(null,bower_data.dependencies);
+  return oresult.map(function(item, idx){
+    var tmp = {};
+    tmp[item] = result[item];
+    return tmp;
+  });
 }
 
 module.exports = {

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -116,7 +116,7 @@ function buildGruntConfiguration(grunt, source, callback){
     uglifyConfig = {};
 
   stylusConfig[path.join('dist','brick.css')] = [];
-  uglifyConfig[path.join('dist','brick.js')] = [path.join(source,'x-tag-core','dist','x-tag-core.js')];
+  uglifyConfig[path.join('dist','brick.js')] = [];
 
   grunt.log.debug('spawning bower tasks');
 
@@ -137,35 +137,46 @@ function buildGruntConfiguration(grunt, source, callback){
 
     grunt.log.debug('iterating over component dependencies');
 
-    Object.keys(dependencies).forEach(function(k){
+    dependencies.forEach(function(item){
+      k = Object.keys(item)[0];
 
       grunt.log.debug('dependency ' + k);
 
-      var stylusFile = dependencies[k].pkgMeta.main.filter(function(f){
+      var stylusFile = item[k].pkgMeta.main.filter(function(f){
         if(f.indexOf('.styl')>-1){
           return true;
         }
-      })[0];
+      });
 
-      var jsFile = dependencies[k].pkgMeta.main.filter(function(f){
+      var jsFile = item[k].pkgMeta.main.filter(function(f){
         if(f.indexOf('.js')>-1){
           return true;
         }
-      })[0];
+      });
 
       var dest = path.join('dist', k);
 
-      if (stylusFile){
-        stylusFile = path.join(source, k, stylusFile);
-        stylusConfig[dest + '.css'] = stylusFile
-        stylusConfig[path.join('dist','brick.css')].push(stylusFile);
-      }
+      stylusFile.forEach(function(file){
+        file = path.join(source, k, file);
+        if (stylusConfig[dest + '.css']){
+          stylusConfig[dest + '.css'].push(file);
+        }
+        else {
+          stylusConfig[dest + '.css'] = [file];
+        }
+        stylusConfig[path.join('dist','brick.css')].push(file);
+      });
 
-      if (jsFile){
-        jsFile = path.join(source, k, jsFile);
-        uglifyConfig[dest + '.js'] = jsFile;
-        uglifyConfig[path.join('dist','brick.js')].push(jsFile);
-      }
+      jsFile.forEach(function(file){
+        file = path.join(source, k, file);
+        if (uglifyConfig[dest + '.js']){
+          uglifyConfig[dest + '.js'].push(file);
+        }
+        else {
+          uglifyConfig[dest + '.js'] = [file];
+        }
+        uglifyConfig[path.join('dist','brick.js')].push(file);
+      });
 
     });
 

--- a/tasks/grunt-cloneRepos.js
+++ b/tasks/grunt-cloneRepos.js
@@ -18,19 +18,19 @@ module.exports = function(grunt){
 
           var bower_data = JSON.parse(result.stdout),
             gitCloneOptions = {},
-            dependencies = tools.flattenBowerDependencies(bower_data),
-            dKeys = Object.keys(dependencies);
+            dependencies = tools.flattenBowerDependencies(bower_data);
 
           grunt.log.write().ok();
 
-          async.forEachSeries(dKeys, function(k, cb){
+          async.forEachSeries(dependencies, function(item, cb){
+            var key = Object.keys(item)[0];
             var args = [
               'clone',
-              dependencies[k].pkgMeta._source.replace('git://','https://') ,
-              path.join('dev-repos', dependencies[k].endpoint.name) ];
+              item[key].pkgMeta._source.replace('git://','https://') ,
+              path.join('dev-repos', item[key].endpoint.name) ];
 
             try {
-              grunt.log.write('Processing '+dependencies[k].endpoint.name+ '\n ');
+              grunt.log.write('Processing '+item[key].endpoint.name+ '\n ');
               grunt.util.spawn({cmd:'git', args: args}, function(e,result){
                 if (e){
                   grunt.log.write(e).warn();


### PR DESCRIPTION
This removes the special treatment of x-tag-core and makes it so our build system relies solely on bower dependencies.  We also support multiple js and stylus files in `main:` now.
