### PR TITLE
Tidy README (better text formatting & structure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ mobile-friendly, cross-browser calendar widget:
 
 That's it! It really is that easy.
 
-## Installation
+## Install
 
 Release bundles are provided on Github under this project's Releases tab.
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
-Brick
-=====
+# Brick
 
 [![Build Status](https://travis-ci.org/mozilla/brick.png)](https://travis-ci.org/mozilla/brick)
 
-Brick is a bundle of re-usable UI components built with [x-tags](http://www.x-tags.org/) for quickly and flexibly building mobile HTML5 apps. Brick adds new HTML tags- widgets that allow developers to express the structure of an application in a clearer, more concise manner.
+Brick is a bundle of re-usable UI components built with
+[x-tags](http://www.x-tags.org/) for quickly and flexibly building mobile HTML5
+apps. Brick adds new HTML tags- widgets that allow developers to express the
+structure of an application in a clearer, more concise manner.
 
-In other words, Brick provides minimal-markup, cross-browser implementations of common user interface designs, from calendars to slidebars to cycleable galleries, taking care of most of the under-the-hood boilerplate for you.
+In other words, Brick provides minimal-markup, cross-browser implementations of
+common user interface designs, from calendars to slidebars to cycling
+galleries, taking care of most of the under-the-hood boilerplate for you.
 
-For example, this is all the markup that would be needed to implement a mobile-friendly, cross-browser calendar widget:
+For example, this is all the markup that would be needed to implement a
+mobile-friendly, cross-browser calendar widget:
 
 ```html
 <x-calendar></x-calendar>
@@ -15,22 +20,48 @@ For example, this is all the markup that would be needed to implement a mobile-f
 
 That's it! It really is that easy.
 
-#Installation
+## Installation
 
 Release bundles are provided on Github under this project's Releases tab.
 
-Prebuilt versions of the entire library are also provided in `dist/brick.css` and `dist/brick.js`, and should be included in your project like any other CSS/JavaScript file.
+Prebuilt versions of the entire library are also provided in
+[`dist/brick.css`](https://github.com/mozilla/brick/blob/master/dist/brick.css)
+and
+[`dist/brick.js`](https://github.com/mozilla/brick/blob/master/dist/brick.js),
+and should be included in your project like any other CSS/JavaScript file.
 
-Compartmentalized releases of specific components are also released in their respective folders under <code>dist</code>, allowing you to pick and choose what components you want.
+Compartmentalized releases of specific components are also released in their
+respective folders under
+[`dist/brick.css`](https://github.com/mozilla/brick/tree/master/dist), allowing
+you to pick and choose what components you want.
 
-## Development Prerequisites
+## Skins
 
-You need three things to get started with Brick.  NPM, Grunt and Bower.
+Each component in Brick can be skinned by creating a new folder in the
+`skins/` directory and then creating a Stylus file with the name of the
+component you wish to style. Once you've created an alternate style for a
+particular element, build it by using the `--skin=` parameter with
+`grunt build` or `grunt build --dev` commands.   All other components will use
+the default styles if a custom style is not provided.
 
-First install [NodeJS/NPM](http://nodejs.org/download/).  Once you have `npm` installed it's easy to install Bower and GruntCLI.   Simply run `npm install -g bower grunt-cli`.
+```bash
+grunt build --skin=solo
+```
 
+## Development
 
-## Building from the repository source
+You need three things to get started with Brick:
+[npm](http://nodejs.org/download/), [Grunt](http://gruntjs.com), and
+[Bower](http://bower.io).
+
+First, install [NodeJS/NPM](http://nodejs.org/download/). Once you have `npm`
+installed it's easy to install Bower and GruntCLI. Run:
+
+```bash
+npm install -g bower grunt-cli
+```
+
+### Building Brick from source
 
 Once you have the prerequisites, you're ready to clone and build from source.
 
@@ -46,17 +77,11 @@ grunt
 
 The built minified files should be output to `dist/brick.css` and `dist/brick.js`.
 
-## Skins
+### Working on components
 
-Each component in Brick can be skinned by creating a new folder in the `./skins/` directory and then creating a Stylus file with the name of the component you wish to style.  Once you've created an alternate style for a particular element, build it by using the `--skin=` parameter with `grunt build` or `grunt build --dev` commands.   All other components will use the default styles if a custom style is not provided.
-
-```bash
-grunt build --skin=solo
-```
-
-## Development
-
-By default, Brick uses Bower to pull in components, which means that they are not git repositories.  If you would like to work on the components within their git repository, then run the following:
+Brick uses Bower to pull in components, which means that they are not git
+repositories. If you would like to work on the components within their git
+repository, run the following:
 
 ```bash
 bower install       # we use bower to get the repository locations, so this is required
@@ -66,86 +91,96 @@ grunt build --dev   # build from repositories instead of bower
 
 Now you can work one each component within their respective git repository.
 
+## Components
 
-# Components
+This is a list of the currently bundled components provided in the library.
 
-This is a list of the currently bundled components provided in the library. (Click to view subfolder with readme and demo page)
+Full documentation can be found on
+[the Brick site](http://mozilla.github.io/brick/).
 
-Full documentation can be found on [the Brick site](http://mozilla.github.io/brick/).
+### Structural Components
 
-## Structural Components
-
-### ['Layout'](https://github.com/x-tag/layout)
+#### ['Layout'](https://github.com/x-tag/layout)
 
 * Primary layout container, holds app structure.
-* Allows whole "app" space to have layout properties like flexbox without affecting <body>
+* Allows whole "app" space to have layout properties like flexbox without
+  affecting <body>
 
-### ['App Bar' (header)](https://github.com/x-tag/appbar)
+#### ['App Bar' (header)](https://github.com/x-tag/appbar)
 
 * Contains top-level information and UI
 * Similar to a toolbar or roughly equivalent to Android's action bar
 
-### ['Tab Bar' (navigation, footer)](https://github.com/x-tag/tabbar)
+#### ['Tab Bar' (navigation, footer)](https://github.com/x-tag/tabbar)
 
 * Used to display an app-level navigation at the bottom of the UI
 * Usually a series of icons with labels.
-* Tabs are linked to panels/views. Changing tab changes the active panel, and changing the active panel changes the tab
-* Essentially fires a 'show' event at targeted elements. It is up to target elements to respond appropriately.
-    - Components with default support for show event:
-        - Slidebox
-        - Flipbox
-        - Deck
+* Tabs are linked to panels/views. Changing tab changes the active panel, and
+  changing the active panel changes the tab
+* Essentially fires a `show` event at targeted elements. It is up to target
+  elements to respond appropriately.
+  * Components with default support for show event:
+    * Deck
+    * Flipbox
+    * Slidebox
 * Can also fire user-defined events
 
-### ['Slidebox'](https://github.com/x-tag/slidebox)
+#### ['Slidebox'](https://github.com/x-tag/slidebox)
 
-* Allows a 'slide' filmstrip effect between views or panels
+* Allows a 'slide' film strip effect between views or panels
 
-### ['Flipbox'](https://github.com/x-tag/flipbox)
+#### ['Flipbox'](https://github.com/x-tag/flipbox)
 
 * Similar to slidebox, but with a perspective flip effect.
 * May be combinable with slidebox and accessed via an option
 
-### ['Deck' ('Cycle'/'Gallery')](https://github.com/x-tag/deck)
+#### ['Deck' ('Cycle'/'Gallery')](https://github.com/x-tag/deck)
 
 * Like a combination of slidebox and flipbox
-* A gallery box in which slides can be cycled in and out independently, with a variety of different transitions
+* A gallery box in which slides can be cycled in and out independently, with a
+  variety of different transitions
 * Transition types can be switched and overridden on the fly, allowing for a
   variety of different entrances/exits
 
-### ['Tooltip' (Callout)](https://github.com/x-tag/tooltip)
+#### ['Tooltip' (Callout)](https://github.com/x-tag/tooltip)
 
 * Content container that appears over current view context
 * Associated with a trigger element in the underlying content
 * Does not necessarily block interaction with underlying content
 
-## Content Components
+### Content Components
 
-### [Calendar](https://github.com/x-tag/calendar)
+#### [Calendar](https://github.com/x-tag/calendar)
 
-* A calendar widget based on/extended from [fortnight.js](https://github.com/potch/fortnight.js), but in a web component format
-* Simple instantiation, with API hooks to allow flexible use cases such as an event-managing calendar (see demo)
+* A calendar widget based on/extended from
+  [fortnight.js](https://github.com/potch/fortnight.js), but in a web
+  component format
+* Simple instantiation, with API hooks to allow flexible use cases such as an
+  event-managing calendar (see demo)
 
-### [Datepicker](https://github.com/x-tag/datepicker)
+#### [Datepicker](https://github.com/x-tag/datepicker)
 
-* A polyfill for &lt;input type='date'&gt;, regardless of native browser support for date inputs
+* A polyfill for &lt;input type='date'&gt;, regardless of native browser
+  support for date inputs
 * Ability to select a date and submit its ISO string to a server
 * Extends upon x-calendar to provide a calendar view
 
-### [Icon Button](https://github.com/x-tag/iconbutton)
+#### [Icon Button](https://github.com/x-tag/iconbutton)
 
 * A simple UI component that creates a button with both an icon and a label
-* Allows multiple anchor locations of the icon and saves the developer from the headache of correctly CSS-centering contents
+* Allows multiple anchor locations of the icon and saves the developer from the
+  headache of correctly CSS-centering contents
 
-### [Slider](https://github.com/x-tag/slider)
+#### [Slider](https://github.com/x-tag/slider)
 
-* Polyfill on top of &lt;input type='range'&gt;, providing a consistent UI regardless of whether type="range" is supported or not.
+* Polyfill on top of `<input type='range'>`, providing a consistent UI
+  regardless of whether `type="range"` is supported or not.
 
-### [Toggle](https://github.com/x-tag/toggle)
+#### [Toggle](https://github.com/x-tag/toggle)
 
 * Unifies checkboxes and radios into a single consistent UI component
 
-### [Togglegroup (aka Option Bar)](https://github.com/x-tag/togglegroup)
+#### [Togglegroup (aka Option Bar)](https://github.com/x-tag/togglegroup)
 
 * A set of associated options of which only one can be selected at a time
 * Designed to appear as a cohesive set

--- a/README.md
+++ b/README.md
@@ -104,18 +104,18 @@ Full documentation can be found on
 
 ### Structural Components
 
-#### ['Layout'](https://github.com/x-tag/layout)
+#### [Layout](https://github.com/x-tag/layout)
 
 * Primary layout container, holds app structure.
 * Allows whole "app" space to have layout properties like flexbox without
   affecting <body>
 
-#### ['App Bar' (header)](https://github.com/x-tag/appbar)
+#### [App Bar (header)](https://github.com/x-tag/appbar)
 
 * Contains top-level information and UI
 * Similar to a toolbar or roughly equivalent to Android's action bar
 
-#### ['Tab Bar' (navigation, footer)](https://github.com/x-tag/tabbar)
+#### [Tab Bar (navigation, footer)](https://github.com/x-tag/tabbar)
 
 * Used to display an app-level navigation at the bottom of the UI
 * Usually a series of icons with labels.
@@ -129,28 +129,17 @@ Full documentation can be found on
     * Slidebox
 * Can also fire user-defined events
 
-#### ['Slidebox'](https://github.com/x-tag/slidebox)
+#### [Deck](https://github.com/x-tag/deck)
 
-* Allows a "slide" film strip effect between views or panels
-
-#### ['Flipbox'](https://github.com/x-tag/flipbox)
-
-* Similar to slidebox, but with a perspective flip effect.
-* May be combinable with slidebox and accessed via an option
-
-#### ['Deck' ('Cycle'/'Gallery')](https://github.com/x-tag/deck)
-
-* Like a combination of slidebox and flipbox
 * A gallery box in which slides can be cycled in and out independently, with a
   variety of different transitions
 * Transition types can be switched and overridden on the fly, allowing for a
   variety of different entrances/exits
 
-#### ['Tooltip' (Callout)](https://github.com/x-tag/tooltip)
+#### [Flipbox](https://github.com/x-tag/flipbox)
 
-* Content container that appears over current view context
-* Associated with a trigger element in the underlying content
-* Does not necessarily block interaction with underlying content
+* Similar to slidebox, but with a perspective flip effect.
+* May be combinable with slidebox and accessed via an option
 
 ### Content Components
 
@@ -162,19 +151,6 @@ Full documentation can be found on
 * Simple instantiation, with API hooks to allow flexible use cases such as an
   event-managing calendar (see demo)
 
-#### [Datepicker](https://github.com/x-tag/datepicker)
-
-* A polyfill for <input type="date">, regardless of native browser
-  support for date inputs
-* Ability to select a date and submit its ISO string to a server
-* Extends upon x-calendar to provide a calendar view
-
-#### [Icon Button](https://github.com/x-tag/iconbutton)
-
-* A simple UI component that creates a button with both an icon and a label
-* Allows multiple anchor locations of the icon and saves the developer from the
-  headache of correctly CSS-centering contents
-
 #### [Slider](https://github.com/x-tag/slider)
 
 * Polyfill on top of `<input type="range">`, providing a consistent UI
@@ -183,9 +159,3 @@ Full documentation can be found on
 #### [Toggle](https://github.com/x-tag/toggle)
 
 * Unifies checkboxes and radios into a single consistent UI component
-
-#### [Togglegroup (aka Option Bar)](https://github.com/x-tag/togglegroup)
-
-* A set of associated options of which only one can be selected at a time
-* Designed to appear as a cohesive set
-* Essentially several Toggles with the appearance of option buttons

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ You need three things to get started with Brick:
 [npm](http://nodejs.org/download/), [Grunt](http://gruntjs.com), and
 [Bower](http://bower.io).
 
-First, install [NodeJS/NPM](http://nodejs.org/download/). Once you have `npm`
-installed it's easy to install Bower and GruntCLI. Run:
+First, install [NodeJS/npm](http://nodejs.org/download/). Once you have `npm`
+installed you need to install Bower and Grunt globally:
 
 ```bash
 npm install -g bower grunt-cli

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ That's it! It really is that easy.
 
 ## Install
 
-Release bundles are provided on Github under this project's Releases tab.
+Release bundles are provided on GitHub, under this
+[project's Releases tab](https://github.com/mozilla/brick/releases).
 
 Prebuilt versions of the entire library are also provided in
 [`dist/brick.css`](https://github.com/mozilla/brick/blob/master/dist/brick.css)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ respective folders under
 [`dist/brick.css`](https://github.com/mozilla/brick/tree/master/dist), allowing
 you to pick and choose what components you want.
 
+Brick is also available as a Bower component: `bower install brick` will
+install Brick for any project using Bower.
+
 ## Skins
 
 Each component in Brick can be skinned by creating a new folder in the

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Full documentation can be found on
 
 #### ['Slidebox'](https://github.com/x-tag/slidebox)
 
-* Allows a 'slide' film strip effect between views or panels
+* Allows a "slide" film strip effect between views or panels
 
 #### ['Flipbox'](https://github.com/x-tag/flipbox)
 
@@ -164,7 +164,7 @@ Full documentation can be found on
 
 #### [Datepicker](https://github.com/x-tag/datepicker)
 
-* A polyfill for &lt;input type='date'&gt;, regardless of native browser
+* A polyfill for <input type="date">, regardless of native browser
   support for date inputs
 * Ability to select a date and submit its ISO string to a server
 * Extends upon x-calendar to provide a calendar view
@@ -177,7 +177,7 @@ Full documentation can be found on
 
 #### [Slider](https://github.com/x-tag/slider)
 
-* Polyfill on top of `<input type='range'>`, providing a consistent UI
+* Polyfill on top of `<input type="range">`, providing a consistent UI
   regardless of whether `type="range"` is supported or not.
 
 #### [Toggle](https://github.com/x-tag/toggle)


### PR DESCRIPTION
This hard-wraps text around 80 characters, which makes blame/diff much more useful for plaintext prose. It also restructures the README into logical sections: Install, Skins, Development, and Components.

It fixes #148.
