### PR TITLE
Fixing byob TypeError: Constructor TextEncoder requires 'new'

### DIFF
--- a/site/js/jszip.js
+++ b/site/js/jszip.js
@@ -98,7 +98,7 @@ JSZip.prototype = (function () {
             // unicode text !
             // unicode string => binary string is a painful process, check if we can avoid it.
             if (JSZip.support.uint8array && typeof TextEncoder === "function") {
-               return TextEncoder("utf-8").encode(result);
+               return new TextEncoder("utf-8").encode(result);
             }
             if (JSZip.support.nodebuffer) {
                return new Buffer(result, "utf-8");
@@ -855,7 +855,7 @@ JSZip.prototype = (function () {
          // http://jsperf.com/utf8encode-vs-textencoder
          // On short strings (file names for example), the TextEncoder API is (currently) slower.
          if (JSZip.support.uint8array && typeof TextEncoder === "function") {
-            var u8 = TextEncoder("utf-8").encode(string);
+            var u8 = new TextEncoder("utf-8").encode(string);
             return JSZip.utils.transformTo("string", u8);
          }
          if (JSZip.support.nodebuffer) {


### PR DESCRIPTION
I was seeing a "TypeError: Constructor TextEncoder requires 'new'" exception when trying to build a bundle. Fix was straight forward. `gh-pages` PR coming.

You can see it working at http://rodms10.github.io/brick/download.html
